### PR TITLE
Add original Efile data for Form 700

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'haml'
 gem 'mailgun-ruby'
 gem 'pg'
 gem 'premailer-rails'
+gem 'rubyzip'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,6 +344,7 @@ DEPENDENCIES
   rails (~> 5.2.1)
   rspec-rails
   rspec_junit_formatter
+  rubyzip
   sass-rails (~> 5.0)
   selenium-webdriver
   spring

--- a/app/lib/disclosure_downloader.rb
+++ b/app/lib/disclosure_downloader.rb
@@ -35,7 +35,14 @@ class DisclosureDownloader
             .map { |row| row.slice('form_Type', 'tran_NamL', 'calculated_Amount') }
         end
 
-      filing.update_attribute(:contents, contents)
+      contents_xml =
+        case filing.form_name
+        when '700'
+          netfile
+            .fetch_calfile_xml(filing.id)
+        end
+
+      filing.update_attributes(contents: contents, contents_xml: contents_xml)
     end
 
     latest = Filing.order(filed_at: :desc).first

--- a/app/lib/forms.rb
+++ b/app/lib/forms.rb
@@ -1,0 +1,33 @@
+module Forms
+  def self.from_filings(filing_array)
+    filing_array.map do |filing|
+      case filing.form_name
+      when '460'
+        Forms::Form460.new(filing)
+      when '700'
+        Forms::Form700.new(filing)
+      else
+        Forms::BaseForm.new(filing)
+      end
+    end
+  end
+
+  class BaseForm
+    delegate :id, :filer_id, :filer_name, :title, :filed_at,
+             :amendment_sequence_number, :amended_filing_id, :form, :form_name,
+             :contents, :contents_xml,
+             to: :@filing
+
+    def initialize(filing)
+      @filing = filing
+    end
+  end
+
+  class BaseXMLForm < BaseForm
+    def initialize(filing)
+      super
+
+      @xml = Nokogiri::XML(contents_xml, &:noblanks) if contents_xml.present?
+    end
+  end
+end

--- a/app/lib/forms/form460.rb
+++ b/app/lib/forms/form460.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Forms
+  class Form460 < BaseForm
+    def total_contributions_received
+      contents_row('F460', '5')['amount_A']
+    end
+
+    def total_expenditures_made
+      contents_row('F460', '11')['amount_A']
+    end
+
+    private
+
+    def contents_row(form_type, line_item)
+      @filing.contents.detect { |r| r['form_Type'] == form_type && r['line_Item'] == line_item }
+    end
+  end
+end

--- a/app/lib/forms/form700.rb
+++ b/app/lib/forms/form700.rb
@@ -1,0 +1,146 @@
+module Forms
+  class Form700 < BaseXMLForm
+    LEGEND = {
+      fair_market_value: [
+        '$2,000-$10,000', '$10,001-$100,000', '$100,001-$1,000,000', 'Over $1,000,000'
+      ].freeze,
+      fair_market_value_schedule_a_2: [
+        '$0-$1,999', '$2,000-$10,000', '$10,001-$100,000', '$100,001-$1,000,000', 'Over $1,000,000'
+      ].freeze,
+      gross_income_received: [
+        '$0-$499', '$500-$1,000', '$1,001-$10,000', '$10,001-$100,000', 'Over $100,000'
+      ].freeze,
+      nature_of_interest: [
+        'Ownership/Deed of Trust', 'Easement', 'Leasehold', 'Other'
+      ].freeze,
+      nature_of_investment: [
+        'Partnership', 'Sole Proprietorship', 'Other'
+      ],
+      gross_income_received_schedule_c_1: [
+        'No Income - Business Position Only', '$500-$1,000', '$1,001-$10,000', '$10,001-$100,000', 'Over $100,000'
+      ].freeze,
+      reason_for_income: [
+        'Salary', "Spouse's or registered domestic partner's income", 'Partnership',
+        'Sale', 'Loan Repayment', 'Commission', 'Rental income', 'Other'
+      ].freeze,
+      business_type: [
+        'Trust', 'Business Entity',
+      ].freeze,
+      type_of_payment: [
+        'Gift', 'Income',
+      ].freeze,
+    }.with_indifferent_access.freeze
+
+    def not_efiled?
+      @xml.blank?
+    end
+
+    def filer_name
+      return super unless @xml.present?
+
+      [@xml.xpath('//disclosure/cover/first_name'), @xml.xpath('//disclosure/cover/last_name')].join(' ')
+    end
+
+    def offices
+      return [] unless @xml.present?
+
+      @xml.xpath('//disclosure/cover/offices/office').map do |office|
+        office.children.each_with_object({}) do |el, hash|
+          hash[el.name] = el.text
+        end
+      end
+    end
+
+    def schedule_a1
+      return [] unless @xml.present?
+
+      @xml.xpath('//disclosure/schedule_a_1s/schedule_a_1').map do |schedule|
+        schedule.children.each_with_object({}) do |el, hash|
+          hash[el.name] = if LEGEND.include?(el.name)
+                            LEGEND[el.name][el.text.to_i - 1]
+                          else
+                            el.text
+                          end
+        end
+      end
+    end
+
+    def schedule_a2
+      return [] unless @xml.present?
+
+      @xml.xpath('//disclosure/schedule_a_2s/schedule_a_2').map do |schedule|
+        schedule.children.each_with_object({}) do |el, hash|
+          hash[el.name] = if LEGEND.include?(el.name)
+                            LEGEND[el.name][el.text.to_i - 1]
+                          else
+                            el.text
+                          end
+        end
+      end
+    end
+
+    def schedule_b
+      return [] unless @xml.present?
+
+      @xml.xpath('//disclosure/schedule_bs/schedule_b').map do |schedule|
+        schedule.children.each_with_object({}) do |el, hash|
+          hash[el.name] = if LEGEND.include?(el.name)
+                            LEGEND[el.name][el.text.to_i - 1]
+                          else
+                            el.text
+                          end
+        end
+      end
+    end
+
+    def schedule_c1
+      return [] unless @xml.present?
+
+      @xml.xpath('//disclosure/schedule_c_1s/schedule_c_1').map do |schedule|
+        schedule.children.each_with_object({}) do |el, hash|
+          hash[el.name] = if LEGEND.include?(el.name)
+                            LEGEND[el.name][el.text.to_i - 1]
+                          else
+                            el.text
+                          end
+        end
+      end
+    end
+
+    def schedule_d
+      return [] unless @xml.present?
+
+      @xml.xpath('//disclosure/schedule_ds/schedule_d').map do |schedule|
+        schedule.children.each_with_object({}) do |el, hash|
+          hash[el.name] = if LEGEND.include?(el.name)
+                            LEGEND[el.name][el.text.to_i - 1]
+                          elsif el.name == 'gifts'
+                            el.xpath('gift').map do |g|
+                              {
+                                'amount' => g.xpath('amount/text()').to_s.to_f,
+                                'description' => g.xpath('description/text()').to_s,
+                                'gift_date' => g.xpath('gift_date/text()').to_s,
+                              }
+                            end
+                          else
+                            el.text
+                          end
+        end
+      end
+    end
+
+    def schedule_e
+      return [] unless @xml.present?
+
+      @xml.xpath('//disclosure/schedule_es/schedule_e').map do |schedule|
+        schedule.children.each_with_object({}) do |el, hash|
+          hash[el.name] = if LEGEND.include?(el.name)
+                            LEGEND[el.name][el.text.to_i - 1]
+                          else
+                            el.text
+                          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/netfile/client.rb
+++ b/app/lib/netfile/client.rb
@@ -3,6 +3,7 @@
 require 'net/http'
 require 'uri'
 require 'json'
+require 'zip'
 
 module Netfile
   # Client to get responses from Netfile
@@ -46,6 +47,27 @@ module Netfile
         raise "Error: More than one page would be returned. Bump PageSize." if num_pages > 1
 
         results
+      end
+    end
+
+    def fetch_calfile_xml(filing_id)
+      Net::HTTP.start(BASE_URL.host, BASE_URL.port, use_ssl: true) do |http|
+        request = Net::HTTP::Get.new(BASE_URL + "public/efile/#{filing_id}")
+        request['Accept'] = 'application/zip'
+
+        response = http.request(request)
+
+        if response.message == 'EfileNotFoundException'
+          # perhaps the filing was removed?
+          return nil
+        end
+
+        raise "Request Failed: " + response.inspect unless response.code.to_i < 300
+
+        Zip::InputStream.open(StringIO.new(response.body)) do |zip|
+          zip.get_next_entry
+          zip.read
+        end
       end
     end
 

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -6,7 +6,7 @@ class AlertMailer < ApplicationMailer
 
   def daily_alert(alert_subscriber, date, filings_in_date_range)
     @alert_subscriber = alert_subscriber
-    @filings = filings_in_date_range
+    @filings = Forms.from_filings(filings_in_date_range)
     @date = date
 
     mail(

--- a/app/models/filing.rb
+++ b/app/models/filing.rb
@@ -8,7 +8,8 @@ class Filing < ApplicationRecord
     'LOB' => 36,          # LOB = Oakland Lobbyist Quarterly Report
     'LOB' => 236,         # LOB = Oakland Lobbyist Quarterly Report
     '497 LCR' => 39,      # LCR = Late Contributions Received
-    '497 LCM' => 38       # LCM = Late Contributions Made
+    '497 LCM' => 38,      # LCM = Late Contributions Made
+    '700' => 254,
   }.freeze
 
   scope :filed_on_date, ->(date) { where("date_trunc('day', filed_at) = ?", date) }

--- a/app/views/alert_mailer/daily_alert.html.haml
+++ b/app/views/alert_mailer/daily_alert.html.haml
@@ -1,6 +1,4 @@
 - @filings.each do |f|
-  - next if f.id == 174032415 # mislabeled as a 460 but it's a 470
-
   %table.filing
     %tbody
       %tr
@@ -22,12 +20,10 @@
         %td
           - if f.form_name == '460'
             %strong Total Contributions Received:
-            - contributions_row = f.contents.detect { |i| i["form_Type"] == "F460" && i["line_Item"] == "5" }
-            = format_money(contributions_row['amount_A'])
+            = format_money(f.total_contributions_received)
             %br
             %strong Total Expenditures Made:
-            - expenditures_row = f.contents.detect { |i| i["form_Type"] == "F460" && i["line_Item"] == "11" }
-            = format_money(expenditures_row['amount_A'])
+            = format_money(f.total_expenditures_made)
 
           - if f.form_name == '497 LCR'
             - total_amount = f.contents.map { |i| i['calculated_Amount'] }.sum
@@ -56,6 +52,46 @@
                 %li #{format_money(contribution['calculated_Amount'])} – #{contribution['tran_NamL']}
               - if f.contents.length > 3
                 %li and #{format_money(total_amount - largest_three_total_amount)} from #{f.contents.length - 3} other contributors
+
+          - if f.form_name == '700'
+            - if f.offices.any?
+              Positions:
+              %ul
+                - f.offices.each do |office|
+                  %li #{office['position']}, #{office['agency']}
+            - if f.schedule_a1.any?
+              Investments (Schedule A1):
+              %ul
+                - f.schedule_a1.each do |investment|
+                  %li #{investment['name_of_business_entity']} - #{investment['fair_market_value']}
+            - if f.schedule_b.any?
+              Real Property (Schedule B):
+              %ul
+                - f.schedule_b.each do |property|
+                  %li #{property['parcel_or_address']}, #{property['city']} - #{property['fair_market_value']}
+            - if f.schedule_c1.any?
+              Income, Loans, and Business Positions (Schedule C):
+              %ul
+                - f.schedule_c1.each do |income|
+                  %li
+                    #{income['business_position']}, #{income['business_activity']}, #{income['name_of_income_source']} -
+                    #{income['gross_income_received_schedule_c_1']}
+            - if f.schedule_d.any?
+              Gifts (Schedule D):
+              %ul
+                - f.schedule_d.each do |gift|
+                  - if gift['gifts'].length > 1
+                    - gifts_string = "#{pluralize(gift['gifts'].length, 'gift')} totaling #{format_money(gift['gifts'].sum { |g| g['amount'] })}"
+                  - else
+                    - gifts_string = "#{gift['gifts'][0]['description']} - #{format_money(gift['gifts'][0]['amount'])}"
+                  %li #{gift['name_of_source']} - #{gifts_string}
+
+            - if f.schedule_e.any?
+              Gifts - Travel Payments (Schedule E):
+              %ul
+                - f.schedule_e.each do |travel|
+                  %li #{travel['name_of_source']} (#{travel['travel_description']}) - #{format_money(travel['amount'].to_f)}
+
 
       %tr
         %td

--- a/db/migrate/20190408194353_add_content_xml_to_filings.rb
+++ b/db/migrate/20190408194353_add_content_xml_to_filings.rb
@@ -1,0 +1,7 @@
+class AddContentXmlToFilings < ActiveRecord::Migration[5.2]
+  def change
+    change_table :filings do |t|
+      t.xml :contents_xml
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_01_205024) do
+ActiveRecord::Schema.define(version: 2019_04_08_194353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2018_12_01_205024) do
     t.string "form"
     t.datetime "filed_at"
     t.json "contents"
+    t.xml "contents_xml"
   end
 
 end


### PR DESCRIPTION
Based on user testing, we learned that our it would be valuable to give
a better overview of Form 700s in the email so that users don't have to
click through for people they marginally care about. Instead, they can
just skim through the email for these people.

This downloads the "Efile.txt", an XML document, from Netfile for the
Form 700's. In order to hold the logic for processing the raw data
returned from Netfile for this form, as well as for Form 460, I've
introduced a new abstraction in app/lib/forms where those helper classes
are responsible for calculating the important numbers based off the raw
form contents.